### PR TITLE
Fix ssh-add calls for machines where there is no ssh-askpass

### DIFF
--- a/ssh-agency.el
+++ b/ssh-agency.el
@@ -215,9 +215,9 @@ ssh-agency always finds the agent without consulting this file."
   "Use `netstat' to find an ssh-agent socket REGEXP."
   (catch 'socket
     (dolist (sock-line (process-lines "netstat" "-f" "unix"))
-      (let ((socket (car (last (split-string sock-line))))
-            (status (and (or (null regexp) (string-match-p regexp socket))
-                         (ssh-agency-socket-status socket))))
+      (let* ((socket (car (last (split-string sock-line))))
+             (status (and (or (null regexp) (string-match-p regexp socket))
+                          (ssh-agency-socket-status socket))))
         (when status
           (throw 'socket (cons status socket)))))))
 


### PR DESCRIPTION
We need to call `ssh-add` with a pty in order to catch the prompt.

ref: https://emacs.stackexchange.com/questions/40564/how-can-magit-add-a-credential-to-ssh-agent/40586